### PR TITLE
added methods to enable/disable gesture capturing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ minZoom:            The minimum zoom factor. (default 0.5)
 
 ```
 
+### Methods
+
+```Text
+
+enable:             Enables all gesture capturing
+disable:            Disables all gesture capturing
+
+```
+
 ## Licence
 
 This is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License, either version 3 of the License, or (at your option) any later version.

--- a/src/pinchzoom.js
+++ b/src/pinchzoom.js
@@ -541,6 +541,20 @@
                         this.is3d = false;
                     }
                 }).bind(this), 0);
+            },
+
+            /**
+             * Enables event handling for gestures
+             */
+            enable: function() {
+              this.enabled = true;
+            },
+
+            /**
+             * Disables event handling for gestures
+             */
+            disable: function() {
+              this.enabled = false;
             }
         };
 
@@ -641,40 +655,45 @@
                 firstMove = true;
 
             el.addEventListener('touchstart', function (event) {
-                firstMove = true;
-                fingers = event.touches.length;
-                detectDoubleTap(event);
+                if(target.enabled) {
+                    firstMove = true;
+                    fingers = event.touches.length;
+                    detectDoubleTap(event);
+                }
             });
 
             el.addEventListener('touchmove', function (event) {
+                if(target.enabled) {
+                    if (firstMove) {
+                        updateInteraction(event);
+                        if (interaction) {
+                            cancelEvent(event);
+                        }
+                        startTouches = targetTouches(event.touches);
+                    } else {
+                        switch (interaction) {
+                            case 'zoom':
+                                target.handleZoom(event, calculateScale(startTouches, targetTouches(event.touches)));
+                                break;
+                            case 'drag':
+                                target.handleDrag(event);
+                                break;
+                        }
+                        if (interaction) {
+                            cancelEvent(event);
+                            target.update();
+                        }
+                    }
 
-                if (firstMove) {
-                    updateInteraction(event);
-                    if (interaction) {
-                        cancelEvent(event);
-                    }
-                    startTouches = targetTouches(event.touches);
-                } else {
-                    switch (interaction) {
-                        case 'zoom':
-                            target.handleZoom(event, calculateScale(startTouches, targetTouches(event.touches)));
-                            break;
-                        case 'drag':
-                            target.handleDrag(event);
-                            break;
-                    }
-                    if (interaction) {
-                        cancelEvent(event);
-                        target.update();
-                    }
+                    firstMove = false;
                 }
-
-                firstMove = false;
             });
 
             el.addEventListener('touchend', function (event) {
-                fingers = event.touches.length;
-                updateInteraction(event);
+                if(target.enabled) {
+                    fingers = event.touches.length;
+                    updateInteraction(event);
+                }
             });
         };
 


### PR DESCRIPTION
Added two methods to allow disabling and enabling of event gestures. Pinchzoom prevents event bubbling when its capturing events so it can interfere with some uses e.g. drawing on a zoomable HTML5.

These methods allow people to temporarily disable event capturing from pinchzoom so that touch events will bubble through the DOM.
