### PR TITLE
Bump version to 2.0

### DIFF
--- a/src/pinchzoom.js
+++ b/src/pinchzoom.js
@@ -80,7 +80,7 @@
 
         /**
          * Pinch zoom
-         * @version 0.0.2
+         * @version 2.0.0
          * @author Manuel Stofer <mst@rtp.ch>
          * @param el
          * @param options


### PR DESCRIPTION
Since jQuery is no longer a dependency this is a breaking change, so we
bump to 2.0.

(under Github releases in this repo 1.0 is already published, so that's
why we're going from 0.0.2 to 2.0.0)