### PR TITLE
fix for IE and ME

### DIFF
--- a/src/pinchzoom.js
+++ b/src/pinchzoom.js
@@ -65,7 +65,7 @@
 
     // utils
     var buildElement = function(str) {
-      var tmp = document.implementation.createHTMLDocument();
+      var tmp = document.implementation.createHTMLDocument(''); // require title parameter for working IE and ME
       tmp.body.innerHTML = str;
       return Array.from(tmp.body.children)[0];
     };


### PR DESCRIPTION
Added param title, empty string. Method createHTMLDocument required title parameter for working IE and ME. Without it, does not work in Internet Explorer and Microsoft edge