### PR TITLE
Fix initial offset of preloaded image

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pz_zoomupdate Zoom factor updated
 pz_dragstart  Started to drag the element
 pz_dragend    Stopped to drag the element
 pz_dragupdate Drag position updated
-pz_doubletap  Resetting the zoom with double-tab
+pz_doubletap  Resetting the zoom with double-tap
 
 ```
 

--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -102,6 +102,7 @@ var definePinchZoom = function () {
             // The image may already be loaded when PinchZoom is initialized,
             // and then the load event (which trigger update) will never fire.
             if (this.isImageLoaded(this.el)) {
+              this.updateAspectRatio();
               this.setupInitialOffset();
             }
 

--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -219,7 +219,7 @@ var definePinchZoom = function () {
                 return;
             }
 
-            this.isDoubleTab = true;
+            this.isDoubleTap = true;
 
             if (startZoomFactor > zoomFactor) {
                 center = this.getCurrentZoomCenter();
@@ -791,7 +791,7 @@ var definePinchZoom = function () {
                             break;
                     }
                 } else {
-                    target.isDoubleTab = false;
+                    target.isDoubleTap = false;
                 }
 
                 if (fingers === 1) {
@@ -809,7 +809,7 @@ var definePinchZoom = function () {
         });
 
         el.addEventListener('touchmove', function (event) {
-            if(target.enabled && !target.isDoubleTab) {
+            if(target.enabled && !target.isDoubleTap) {
                 if (firstMove) {
                     updateInteraction(event);
                     if (interaction) {


### PR DESCRIPTION
This fixes the issue that the image becomes offset too far (50% of its size) to the right and up, if the image has already been loaded upon initialisation of PinchZoom.

The solution is to set the height of the container _before_ the initial offset is computed, as the initial offset depends on the zoom factor and the zoom factor becomes zero if the container height is zero.

A minor variable name typo has also been fixed, _'tab'_ -> _'tap'_.