### PR TITLE
Fix: remove unnecessary arrow function

### DIFF
--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -248,7 +248,7 @@ var definePinchZoom = function () {
             if (el.nodeName === 'IMG') {
               return el.complete && el.naturalHeight !== 0;
             } else {
-              return Array.from(el.querySelectorAll('img')).every((img) => this.isImageLoaded(img));
+              return Array.from(el.querySelectorAll('img')).every(this.isImageLoaded);
             }
         },
 


### PR DESCRIPTION
This arrow function makes Uglify to fails in our project, plus I guess
it wouldn't work in browser that does not support them (as IE11).
Since it seems the only one in the project, and since it's also
unnecessary, I can see only benefits from remove it.