### PR TITLE
Allow drag events to pass through

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ zoomOutFactor:      Resizes to original size when zoom factor is below this valu
 animationDuration:  Animation duration in milliseconds. (default 300)
 maxZoom:            Maximum zoom factor. (default 4)
 minZoom:            Minimum zoom factor. (default 0.5)
+draggableUnzoomed:  Capture drag events even when the image isn't zoomed. (default true)
+                    (using `false` allows other libs (e.g. swipe) to pick up drag events)
 lockDragAxis:       Lock panning of the element to a single axis. (default false)
 use2d:              Fall back to 2D transforms when idle. (default true)
                     (a truthy value will still use 3D transforms during animation)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ animationDuration:  Animation duration in milliseconds. (default 300)
 maxZoom:            Maximum zoom factor. (default 4)
 minZoom:            Minimum zoom factor. (default 0.5)
 lockDragAxis:       Lock panning of the element to a single axis. (default false)
+use2d:              Fall back to 2D transforms when idle. (default true)
+                    (a truthy value will still use 3D transforms during animation)
+verticalPadding:    Vertical padding to apply around the image. (default 0)
+horizontalPadding:  Horizontal padding to apply around the image. (default 0)
 ```
 
 ### Events

--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -124,6 +124,7 @@ var definePinchZoom = function () {
             animationDuration: 300,
             maxZoom: 4,
             minZoom: 0.5,
+            draggableUnzoomed: true,
             lockDragAxis: false,
             use2d: true,
             zoomStartEventName: 'pz_zoomstart',
@@ -318,6 +319,18 @@ var definePinchZoom = function () {
             this.zoomFactor *= scale;
             this.zoomFactor = Math.min(this.options.maxZoom, Math.max(this.zoomFactor, this.options.minZoom));
             return this.zoomFactor / originalZoomFactor;
+        },
+
+        /**
+         * Determine if the image is in a draggable state
+         *
+         * When the image can be dragged, the drag event is acted upon and cancelled.
+         * When not draggable, the drag event bubbles through this component.
+         *
+         * @return {Boolean}
+         */
+        canDrag: function () {
+            return this.options.draggableUnzoomed || !isCloseTo(this.zoomFactor, 1);
         },
 
         /**
@@ -737,7 +750,7 @@ var definePinchZoom = function () {
             updateInteraction = function (event) {
                 if (fingers === 2) {
                     setInteraction('zoom');
-                } else if (fingers === 1) {
+                } else if (fingers === 1 && target.canDrag()) {
                     setInteraction('drag', event);
                 } else {
                     setInteraction(null, event);


### PR DESCRIPTION
This more or less re-instates the `canDrag` method, that was removed earlier, but now with the option to bypass the method.

Using this allows drag events to pass through this component, so that others may listen to those events (e.g. a swipe library).

This fixes #61.