### PR TITLE
Offset and size fixes (related to events)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ minZoom:            Minimum zoom factor. (default 0.5)
 draggableUnzoomed:  Capture drag events even when the image isn't zoomed. (default true)
                     (using `false` allows other libs (e.g. swipe) to pick up drag events)
 lockDragAxis:       Lock panning of the element to a single axis. (default false)
+setOffsetsOnce:     Compute offsets (image position inside container) only once. (default false)
+                    (using `true` maintains the offset on consecutive `load` and `resize`)
 use2d:              Fall back to 2D transforms when idle. (default true)
                     (a truthy value will still use 3D transforms during animation)
 verticalPadding:    Vertical padding to apply around the image. (default 0)
@@ -50,6 +52,8 @@ pz_dragupdate Drag position updated
 pz_doubletap  Resetting the zoom with double-tap
 
 ```
+
+_(if need be, the event names can be customized via `options`)_
 
 ### Methods
 

--- a/dist/pinch-zoom.umd.js
+++ b/dist/pinch-zoom.umd.js
@@ -284,12 +284,6 @@
             },
 
             setupOffsets: function setupOffsets() {
-                if (this._initialOffsetSetup) {
-                    return;
-                }
-
-                this._initialOffsetSetup = true;
-
                 this.computeInitialOffset();
                 this.resetOffset();
             },
@@ -676,8 +670,7 @@
 
                     if (event && event.type === 'resize') {
                         this.updateAspectRatio();
-                        this.computeInitialOffset();
-                        this.resetOffset();
+                        this.setupOffsets();
                     }
 
                     if (event && event.type === 'load') {

--- a/dist/pinch-zoom.umd.js
+++ b/dist/pinch-zoom.umd.js
@@ -148,6 +148,7 @@
                 minZoom: 0.5,
                 draggableUnzoomed: true,
                 lockDragAxis: false,
+                setOffsetsOnce: false,
                 use2d: true,
                 zoomStartEventName: 'pz_zoomstart',
                 zoomUpdateEventName: 'pz_zoomupdate',
@@ -284,6 +285,12 @@
             },
 
             setupOffsets: function setupOffsets() {
+                if (this.options.setOffsetsOnce && this._isOffsetsSet) {
+                    return;
+                }
+
+                this._isOffsetsSet = true;
+
                 this.computeInitialOffset();
                 this.resetOffset();
             },

--- a/dist/pinch-zoom.umd.js
+++ b/dist/pinch-zoom.umd.js
@@ -673,14 +673,15 @@
 
                 window.setTimeout(function () {
                     this.updatePlaned = false;
-                    this.updateAspectRatio();
 
                     if (event && event.type === 'resize') {
+                        this.updateAspectRatio();
                         this.computeInitialOffset();
                         this.resetOffset();
                     }
 
                     if (event && event.type === 'load') {
+                        this.updateAspectRatio();
                         this.setupOffsets();
                     }
 

--- a/dist/pinch-zoom.umd.js
+++ b/dist/pinch-zoom.umd.js
@@ -126,7 +126,7 @@
             // and then the load event (which trigger update) will never fire.
             if (this.isImageLoaded(this.el)) {
                 this.updateAspectRatio();
-                this.setupInitialOffset();
+                this.setupOffsets();
             }
 
             this.enable();
@@ -265,6 +265,14 @@
             },
 
             /**
+             * Reset current image offset to that of the initial offset
+             */
+            resetOffset: function resetOffset() {
+                this.offset.x = this.initialOffset.x;
+                this.offset.y = this.initialOffset.y;
+            },
+
+            /**
              * Determine if image is loaded
              */
             isImageLoaded: function isImageLoaded(el) {
@@ -275,7 +283,7 @@
                 }
             },
 
-            setupInitialOffset: function setupInitialOffset() {
+            setupOffsets: function setupOffsets() {
                 if (this._initialOffsetSetup) {
                     return;
                 }
@@ -283,8 +291,7 @@
                 this._initialOffsetSetup = true;
 
                 this.computeInitialOffset();
-                this.offset.x = this.initialOffset.x;
-                this.offset.y = this.initialOffset.y;
+                this.resetOffset();
             },
 
             /**
@@ -476,9 +483,13 @@
             },
 
             /**
-             * Updates the aspect ratio
+             * Updates the container aspect ratio
+             *
+             * Any previous container height must be cleared before re-measuring the
+             * parent height, since it depends implicitly on the height of any of its children
              */
             updateAspectRatio: function updateAspectRatio() {
+                this.unsetContainerY();
                 this.setContainerY(this.container.parentElement.offsetHeight);
             },
 
@@ -604,6 +615,10 @@
                 return this.container.style.height = y + 'px';
             },
 
+            unsetContainerY: function unsetContainerY() {
+                this.container.style.height = null;
+            },
+
             /**
              * Creates the expected html structure
              */
@@ -662,10 +677,11 @@
 
                     if (event && event.type === 'resize') {
                         this.computeInitialOffset();
+                        this.resetOffset();
                     }
 
                     if (event && event.type === 'load') {
-                        this.setupInitialOffset();
+                        this.setupOffsets();
                     }
 
                     var zoomFactor = this.getInitialZoomFactor() * this.zoomFactor,

--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -128,6 +128,7 @@ var definePinchZoom = function () {
             minZoom: 0.5,
             draggableUnzoomed: true,
             lockDragAxis: false,
+            setOffsetsOnce: false,
             use2d: true,
             zoomStartEventName: 'pz_zoomstart',
             zoomUpdateEventName: 'pz_zoomupdate',
@@ -264,6 +265,12 @@ var definePinchZoom = function () {
         },
 
         setupOffsets: function() {
+            if (this.options.setOffsetsOnce && this._isOffsetsSet) {
+              return;
+            }
+
+            this._isOffsetsSet = true;
+
             this.computeInitialOffset();
             this.resetOffset();
         },

--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -105,7 +105,7 @@ var definePinchZoom = function () {
             // and then the load event (which trigger update) will never fire.
             if (this.isImageLoaded(this.el)) {
               this.updateAspectRatio();
-              this.setupInitialOffset();
+              this.setupOffsets();
             }
 
             this.enable();
@@ -245,6 +245,14 @@ var definePinchZoom = function () {
         },
 
         /**
+         * Reset current image offset to that of the initial offset
+         */
+        resetOffset: function() {
+            this.offset.x = this.initialOffset.x;
+            this.offset.y = this.initialOffset.y;
+        },
+
+        /**
          * Determine if image is loaded
          */
         isImageLoaded: function (el) {
@@ -255,7 +263,7 @@ var definePinchZoom = function () {
             }
         },
 
-        setupInitialOffset: function() {
+        setupOffsets: function() {
             if (this._initialOffsetSetup) {
               return;
             }
@@ -263,8 +271,7 @@ var definePinchZoom = function () {
             this._initialOffsetSetup = true;
 
             this.computeInitialOffset();
-            this.offset.x = this.initialOffset.x;
-            this.offset.y = this.initialOffset.y;
+            this.resetOffset();
         },
 
         /**
@@ -463,9 +470,13 @@ var definePinchZoom = function () {
         },
 
         /**
-         * Updates the aspect ratio
+         * Updates the container aspect ratio
+         *
+         * Any previous container height must be cleared before re-measuring the
+         * parent height, since it depends implicitly on the height of any of its children
          */
         updateAspectRatio: function () {
+            this.unsetContainerY();
             this.setContainerY(this.container.parentElement.offsetHeight);
         },
 
@@ -589,6 +600,10 @@ var definePinchZoom = function () {
             return this.container.style.height = y + 'px';
         },
 
+        unsetContainerY: function () {
+            this.container.style.height = null;
+        },
+
         /**
          * Creates the expected html structure
          */
@@ -647,10 +662,11 @@ var definePinchZoom = function () {
 
                 if (event && event.type === 'resize') {
                     this.computeInitialOffset();
+                    this.resetOffset();
                 }
 
                 if (event && event.type === 'load') {
-                  this.setupInitialOffset();
+                  this.setupOffsets();
                 }
 
                 var zoomFactor = this.getInitialZoomFactor() * this.zoomFactor,

--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -264,12 +264,6 @@ var definePinchZoom = function () {
         },
 
         setupOffsets: function() {
-            if (this._initialOffsetSetup) {
-              return;
-            }
-
-            this._initialOffsetSetup = true;
-
             this.computeInitialOffset();
             this.resetOffset();
         },
@@ -661,8 +655,7 @@ var definePinchZoom = function () {
 
                 if (event && event.type === 'resize') {
                     this.updateAspectRatio();
-                    this.computeInitialOffset();
-                    this.resetOffset();
+                    this.setupOffsets();
                 }
 
                 if (event && event.type === 'load') {

--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -658,14 +658,15 @@ var definePinchZoom = function () {
 
             window.setTimeout((function () {
                 this.updatePlaned = false;
-                this.updateAspectRatio();
 
                 if (event && event.type === 'resize') {
+                    this.updateAspectRatio();
                     this.computeInitialOffset();
                     this.resetOffset();
                 }
 
                 if (event && event.type === 'load') {
+                  this.updateAspectRatio();
                   this.setupOffsets();
                 }
 


### PR DESCRIPTION
Various fixes for aspect ratio (container height) and offset (image positioning), when `load` and `resize` events occur.

These fixes address the following issues:
- On `resize`, the image offset was not updated
- On `resize`, the container height was set to the wrong value (as it affects the parent height)
- On the 2<sup>nd</sup> `load`, no offset values were updated, effectively making PinchZoom not adjust to images that change their `src` attribute
- On `touchmove` and during animation (high frequency events), there were unnecessary calls to update the aspect ratio (in which an inline `height` style is updated on the container element)