### PR TITLE
Patch `undefined is not an object` error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+
+.git

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 node_modules
-
-.git

--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -851,7 +851,9 @@ var definePinchZoom = function () {
                 } else {
                     switch (interaction) {
                         case 'zoom':
-                            target.handleZoom(event, calculateScale(startTouches, targetTouches(event.touches)));
+                            if (startTouches.length == 2 && event.touches.length == 2) {
+                                target.handleZoom(event, calculateScale(startTouches, targetTouches(event.touches)));
+                            }
                             break;
                         case 'drag':
                             target.handleDrag(event);

--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -187,7 +187,7 @@ var definePinchZoom = function () {
          * @param event
          */
         handleZoom: function (event, newScale) {
-          if (!newScale) return
+            if (!newScale) return
             // a relative scale factor is used
             var touchCenter = this.getTouchCenter(this.getTouches(event)),
                 scale = newScale / this.lastScale;

--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -187,6 +187,7 @@ var definePinchZoom = function () {
          * @param event
          */
         handleZoom: function (event, newScale) {
+          if (!newScale) return
             // a relative scale factor is used
             var touchCenter = this.getTouchCenter(this.getTouches(event)),
                 scale = newScale / this.lastScale;
@@ -786,6 +787,7 @@ var definePinchZoom = function () {
             },
 
             getDistance = function (a, b) {
+                if (!a || !b) return null;
                 var x, y;
                 x = a.x - b.x;
                 y = a.y - b.y;
@@ -795,6 +797,8 @@ var definePinchZoom = function () {
             calculateScale = function (startTouches, endTouches) {
                 var startDistance = getDistance(startTouches[0], startTouches[1]),
                     endDistance = getDistance(endTouches[0], endTouches[1]);
+
+                if (!startDistance || !endDistance) return null;
                 return endDistance / startDistance;
             },
 

--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -187,7 +187,6 @@ var definePinchZoom = function () {
          * @param event
          */
         handleZoom: function (event, newScale) {
-            if (!newScale) return;
             // a relative scale factor is used
             var touchCenter = this.getTouchCenter(this.getTouches(event)),
                 scale = newScale / this.lastScale;
@@ -787,7 +786,6 @@ var definePinchZoom = function () {
             },
 
             getDistance = function (a, b) {
-                if (!a || !b) return null;
                 var x, y;
                 x = a.x - b.x;
                 y = a.y - b.y;
@@ -797,8 +795,6 @@ var definePinchZoom = function () {
             calculateScale = function (startTouches, endTouches) {
                 var startDistance = getDistance(startTouches[0], startTouches[1]),
                     endDistance = getDistance(endTouches[0], endTouches[1]);
-
-                if (!startDistance || !endDistance) return null;
                 return endDistance / startDistance;
             },
 

--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -187,7 +187,7 @@ var definePinchZoom = function () {
          * @param event
          */
         handleZoom: function (event, newScale) {
-            if (!newScale) return
+            if (!newScale) return;
             // a relative scale factor is used
             var touchCenter = this.getTouchCenter(this.getTouches(event)),
                 scale = newScale / this.lastScale;


### PR DESCRIPTION
See: https://github.com/manuelstofer/pinchzoom/issues/70

I added case-handling for if a `touches` array has a null or missing object.

**Please make sure to verify these changes work as intended:** If there's a missing object, `handleZoom` will be a no-op; otherwise, everything should execute as usual.