### PR TITLE
Add onUpdate callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ onDragStart:        Callback for dragstart event (params: Pinchzoom object, Even
 onDragEnd:          Callback for dragend event (params: Pinchzoom object, Event event) (default null)
 onDragUpdate:       Callback for dragupdate event (params: Pinchzoom object, Event event) (default null)
 onDoubleTap:        Callback for doubletap event (params: Pinchzoom object, Event event) (default null)
+onUpdate:           Callback for update event (params: Pinchzoom object, Event event) (default null)
 ```
 
 ### Methods

--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -145,7 +145,8 @@ var definePinchZoom = function () {
             onDragStart: null,
             onDragEnd: null,
             onDragUpdate: null,
-            onDoubleTap: null
+            onDoubleTap: null,
+            onUpdate: null
         },
 
         /**
@@ -743,6 +744,10 @@ var definePinchZoom = function () {
                     this.el.style.transform = transform2d;
 
                     this.is3d = false;
+                }
+
+                if(typeof this.options.onUpdate == "function"){
+                    this.options.onUpdate(this, event)
                 }
             }).bind(this), 0);
         },


### PR DESCRIPTION
Because the container calculation is wrapped in a `setTimeout` callback, it is difficult to trigger anything after this is called. Adding an `onUpdate` callback inside there allows easily hooking into this. 

Updated the docs to include this also.