### PR TITLE
separate initialization of `sum` and `isCloseTo` from `PinchZoom`

### DIFF
--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -110,11 +110,11 @@ var definePinchZoom = function () {
 
             this.enable();
 
-        },
-        sum = function (a, b) {
+        };
+    var sum = function (a, b) {
             return a + b;
-        },
-        isCloseTo = function (value, expected) {
+        };
+    var isCloseTo = function (value, expected) {
             return value > expected - 0.01 && value < expected + 0.01;
         };
 


### PR DESCRIPTION
This fixes a bug with TypeScript 4.0.5 for certain compilation paths.
See https://github.com/angular/angular-cli/issues/19317#issuecomment-723259141