### PR TITLE
Declare `IPinchZoomOptions` so it can be referenced outside the const…

### DIFF
--- a/src/pinch-zoom.d.ts
+++ b/src/pinch-zoom.d.ts
@@ -1,6 +1,6 @@
 type PinchZoomEventHandler = (target: PinchZoom, event: TouchEvent) => void;
 
-interface IPinchZoomOptions {
+declare interface IPinchZoomOptions {
     tapZoomFactor?: number;
     zoomOutFactor?: number;
     animationDuration?: number;


### PR DESCRIPTION
Declare `IPinchZoomOptions` so it can be referenced outside the constructor